### PR TITLE
Cameras Sidebar Collapsible

### DIFF
--- a/src/components/cameras/CameraSidebar.tsx
+++ b/src/components/cameras/CameraSidebar.tsx
@@ -1,14 +1,15 @@
-import React, { useState } from 'react';
+import React, { forwardRef, useImperativeHandle, useState } from 'react';
 import { ListGroup } from 'flowbite-react';
+import { TbLayoutSidebarLeftCollapse, TbLayoutSidebarLeftExpand } from "react-icons/tb";
 import { Section } from '@/app/cameras/defs'
 
 interface CameraSidebarProps {
   onSectionSelect: (section: Section) => void;
 }
 
-const CameraSidebar = ({ onSectionSelect}: CameraSidebarProps) => {
+const CameraSidebar = forwardRef(({ onSectionSelect}: CameraSidebarProps, ref) => {
   const sections: Section[] = ['alberta-highways', 'calgary-cameras', 'edmonton-cameras', 'banff-cameras'];
-  
+  const [isOpen, setIsOpen] = useState(true);
   const [activeSectionIndex, setActiveSectionIndex] = useState(0);
 
   const handleSelect = (index: number) => {
@@ -16,21 +17,44 @@ const CameraSidebar = ({ onSectionSelect}: CameraSidebarProps) => {
     onSectionSelect(sections[index]);
   };
 
-  return (
-    <div className="w-80 min-h-screen bg-gray-100 p-4 fixed left-0">
-      <ListGroup>
-        {sections.map((section, index) => (
-          <ListGroup.Item 
-            key={section}
-            onClick={() => handleSelect(index)}
-            active={index === activeSectionIndex} // Highlight if this section is selected
-          >
-            {section.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')}
-          </ListGroup.Item>
-        ))}
-      </ListGroup>
-    </div>
-  );
-};
+  const handleToggleSidebar = () => {
+    setIsOpen(!isOpen);
+  };
 
-export default React.memo(CameraSidebar);
+  useImperativeHandle(ref, () => ({
+    handleToggleSidebar,
+  }));
+
+  return (
+    <>
+      <style jsx>{`
+        .translate-x-80 {
+          transform: translateX(-100%);
+       }`
+      }</style>
+      <div>
+        {
+          isOpen ?
+            <TbLayoutSidebarLeftCollapse onClick={handleToggleSidebar} size={35} style={{ position: 'fixed', zIndex: 2, marginLeft: `${isOpen ? '0%' : '0%'}`, color: 'black' }} /> :
+            <TbLayoutSidebarLeftExpand onClick={handleToggleSidebar} size={35} style={{ position: 'fixed', zIndex: 2, marginLeft: `${isOpen ? '1%' : '0%'}`, color: 'black' }} />
+        }
+      </div>
+      <div className={`w-80 min-h-screen bg-gray-100 p-4 py-10 fixed z-index-2000 transform transition-transform duration-300 ${isOpen ? '' : 'translate-x-80'}`}>
+        <ListGroup>
+          {sections.map((section, index) => (
+            <ListGroup.Item 
+              key={section}
+              onClick={() => handleSelect(index)}
+              active={index === activeSectionIndex} // Highlight if this section is selected
+            >
+              {section.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')}
+            </ListGroup.Item>
+          ))}
+        </ListGroup>
+      </div>
+    </>
+  );
+});
+
+CameraSidebar.displayName = "Camera Sidebar";
+export default CameraSidebar;

--- a/src/components/cameras/Cameras.tsx
+++ b/src/components/cameras/Cameras.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, FC } from 'react';
+import React, { useState, useCallback, FC, useRef } from 'react';
 import CameraSidebar from '@/components/cameras/CameraSidebar';
 import CameraGrid from '@/components/cameras/CameraGrid';
 import CameraGridSize from '@/components/cameras/CameraGridSize';
@@ -10,6 +10,7 @@ const Cameras: FC<CamerasProps> = ({}) => {
   const [selectedSection, setSelectedSection] = useState('alberta-highways');
   const [gridSize, setGridSize] = useState('grid-cols-3');
 
+  const sidebarRef = useRef();
   const reduceColumns = useCallback(() => {
     if (gridSize === 'grid-cols-5') {
       setGridSize('grid-cols-4');
@@ -27,9 +28,9 @@ const Cameras: FC<CamerasProps> = ({}) => {
   }, [gridSize, setGridSize]);
 
   return (
-    <div className="flex min-h-screen">
-      <CameraSidebar onSectionSelect={setSelectedSection}/>
-      <div className="flex-1 overflow-auto bg-white min-h-screen ml-80">
+    <div className="flex min-h-screen bg-white">
+      <CameraSidebar ref={sidebarRef} onSectionSelect={setSelectedSection}/>
+      <div className="flex-1 overflow-auto min-h-screen">
         <CameraGrid section={selectedSection as Section} gridSize={gridSize} />
       </div>
       <CameraGridSize onReduceColumns={reduceColumns} onAddColumns={addColumns} gridSize={gridSize} />


### PR DESCRIPTION
#50
- Grid UI needs updated padding so button is not overlapping an item or add a background to the button
- Grid Items need to flex to bigger sizes so we can use 1 column on mobile version
- Spinners are loading on top of the sidebar (z-index didn't seem to fix it so it is probably how the spinners are rendered)
![Screen Shot 2023-05-21 at 11 37 59 AM](https://github.com/ProvinceWatch/open-watch/assets/89932630/fe211fd8-a119-4b7f-9696-2f9e31f89446)
![Screen Shot 2023-05-21 at 11 37 51 AM](https://github.com/ProvinceWatch/open-watch/assets/89932630/c5ad8b91-f298-49a9-af75-5bc76f5a9830)
