### PR TITLE
Moving camera components

### DIFF
--- a/src/app/cameras/page.tsx
+++ b/src/app/cameras/page.tsx
@@ -6,9 +6,13 @@ import NavBar from '@/components/NavBar';
 
 export default function CamerasPage() {
   return (
-    <>
-      <NavBar selectedTab='cameras'/>
-      <Cameras />
-    </>
+    <div>
+      <div className='sticky top-0 z-50'>
+        <NavBar selectedTab='cameras' />
+      </div>
+      <div>
+        <Cameras />
+      </div>
+    </div>
   );
 }

--- a/src/app/cameras/page.tsx
+++ b/src/app/cameras/page.tsx
@@ -7,7 +7,7 @@ import NavBar from '@/components/NavBar';
 export default function CamerasPage() {
   return (
     <div>
-      <div className='sticky top-0 z-50'>
+      <div className='sticky w-full top-0 z-50'>
         <NavBar selectedTab='cameras' />
       </div>
       <div>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -18,16 +18,16 @@ const NavBar: FC<NavBarProps> = ({ selectedTab }) => {
         <DarkThemeToggle className="ml-auto"/>
         <Navbar.Toggle />
         <Navbar.Collapse className='ml-4'>
-          <Link href="/home" className={`${selectedTab == 'home' ? 'text-blue dark:text-white' : 'text-black dark: text-gray-400'}`}>
+          <Link href="/home" className={`${selectedTab == 'home' ? 'text-blue dark:text-white' : 'text-black dark:text-gray-400'}`}>
             Home
           </Link>
-          <Link href="/map" className={`${selectedTab == 'map' ? 'text-blue dark:text-white' : 'text-black dark: text-gray-400'}`}>
+          <Link href="/map" className={`${selectedTab == 'map' ? 'text-blue dark:text-white' : 'text-black dark:text-gray-400'}`}>
             Map
           </Link>
-          <Link href="/cameras" className={`${selectedTab == 'cameras' ? 'text-blue dark:text-white' : 'text-black dark: text-gray-400'}`}>
+          <Link href="/cameras" className={`${selectedTab == 'cameras' ? 'text-blue dark:text-white' : 'text-black dark:text-gray-400'}`}>
             Traffic Cameras
           </Link>
-          <Link href="/open-data" className={`${selectedTab == 'open-data' ? 'text-blue dark:text-white' : 'text-black dark: text-gray-400'}`}>
+          <Link href="/open-data" className={`${selectedTab == 'open-data' ? 'text-blue dark:text-white' : 'text-black dark:text-gray-400'}`}>
             Open Data
           </Link>
         </Navbar.Collapse>

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -12,20 +12,29 @@ interface PaginationProps {
 
 const Pagination: React.FC<PaginationProps> = ({ currentPage, totalPages, onNextPage, onPrevPage, onGoToBeginning, onGoToLast }) => {
   return (
-    <div className="flex items-center justify-center my-2 gap-4">
-      <Button onClick={onGoToBeginning} disabled={currentPage === 1} className='bg-black enabled:hover:bg-gray-600 dark:bg-white dark:enabled:hover:bg-gray-600 dark:enabled:hover:text-white dark:text-black'>
-        First
-      </Button>
-      <Button onClick={onPrevPage} disabled={currentPage === 1} className='bg-black enabled:hover:bg-gray-600 dark:bg-white dark:enabled:hover:bg-gray-600 dark:enabled:hover:text-white dark:text-black'>
-        Previous
-      </Button>
-      <span className="text-black dark:text-white">{`Page ${currentPage} of ${totalPages}`}</span>
-      <Button onClick={onNextPage} disabled={currentPage === totalPages} className='bg-black enabled:hover:bg-gray-600 dark:bg-white dark:enabled:hover:bg-gray-600 dark:enabled:hover:text-white dark:text-black'>
-        Next
-      </Button>
-      <Button onClick={onGoToLast} disabled={currentPage === totalPages} className='bg-black enabled:hover:bg-gray-600 dark:bg-white dark:enabled:hover:bg-gray-600 dark:enabled:hover:text-white dark:text-black'>
-        Last
-      </Button>
+    <div className="flex items-center justify-center my-2 gap-2">
+      <div className="flex items-center justify-center gap-2">
+        <Button onClick={onPrevPage} disabled={currentPage === 1} className="bg-black enabled:hover:bg-gray-600 dark:bg-white dark:enabled:hover:bg-gray-600 dark:enabled:hover:text-white dark:text-black">
+          Previous
+        </Button>
+        <Button onClick={onGoToBeginning} disabled={currentPage === 1} className="bg-black enabled:hover:bg-gray-600 dark:bg-white dark:enabled:hover:bg-gray-600 dark:enabled:hover:text-white dark:text-black">
+          First
+        </Button>
+      </div>
+
+      <div className="text-black dark:text-white">
+        <span className="hidden sm:inline">{`Page ${currentPage} of ${totalPages}`}</span>
+        <span className="sm:hidden">{`${currentPage}/${totalPages}`}</span>
+      </div>
+
+      <div className="flex items-center justify-center gap-2">
+        <Button onClick={onNextPage} disabled={currentPage === totalPages} className="bg-black enabled:hover:bg-gray-600 dark:bg-white dark:enabled:hover:bg-gray-600 dark:enabled:hover:text-white dark:text-black">
+          Next
+        </Button>
+        <Button onClick={onGoToLast} disabled={currentPage === totalPages} className="bg-black enabled:hover:bg-gray-600 dark:bg-white dark:enabled:hover:bg-gray-600 dark:enabled:hover:text-white dark:text-black">
+          Last
+        </Button>
+      </div>
     </div>
   );
 };

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -14,11 +14,11 @@ const Pagination: React.FC<PaginationProps> = ({ currentPage, totalPages, onNext
   return (
     <div className="flex items-center justify-center my-2 gap-2">
       <div className="flex items-center justify-center gap-2">
-        <Button onClick={onPrevPage} disabled={currentPage === 1} className="bg-black enabled:hover:bg-gray-600 dark:bg-white dark:enabled:hover:bg-gray-600 dark:enabled:hover:text-white dark:text-black">
-          Previous
-        </Button>
         <Button onClick={onGoToBeginning} disabled={currentPage === 1} className="bg-black enabled:hover:bg-gray-600 dark:bg-white dark:enabled:hover:bg-gray-600 dark:enabled:hover:text-white dark:text-black">
           First
+        </Button>
+        <Button onClick={onPrevPage} disabled={currentPage === 1} className="bg-black enabled:hover:bg-gray-600 dark:bg-white dark:enabled:hover:bg-gray-600 dark:enabled:hover:text-white dark:text-black">
+          Previous
         </Button>
       </div>
 

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -12,7 +12,7 @@ interface PaginationProps {
 
 const Pagination: React.FC<PaginationProps> = ({ currentPage, totalPages, onNextPage, onPrevPage, onGoToBeginning, onGoToLast }) => {
   return (
-    <div className="flex items-center justify-center my-2 gap-2">
+    <div className="flex items-center justify-center mb-2 gap-2">
       <div className="flex items-center justify-center gap-2">
         <Button onClick={onGoToBeginning} disabled={currentPage === 1} className="bg-black enabled:hover:bg-gray-600 dark:bg-white dark:enabled:hover:bg-gray-600 dark:enabled:hover:text-white dark:text-black">
           First

--- a/src/components/cameras/CameraCard.tsx
+++ b/src/components/cameras/CameraCard.tsx
@@ -5,9 +5,10 @@ import { CameraData } from '@/app/map/defs';
 interface CameraCardProps {
   camera: CameraData;
   onSelect: (camera: CameraData) => void;
+  columns: number;
 }
 
-const CameraCard: React.FC<CameraCardProps> = ({ camera, onSelect }) => {
+const CameraCard: React.FC<CameraCardProps> = ({ camera, onSelect, columns }) => {
   const [loading, setLoading] = useState(true); 
 
   useEffect(() => {
@@ -36,6 +37,23 @@ const CameraCard: React.FC<CameraCardProps> = ({ camera, onSelect }) => {
     }
   };
 
+  const calculateTextSize = () => {
+    switch (columns) {
+      case 1:
+        return 'text-3xl lg:text-4xl';
+      case 2:
+        return 'text-2xl';
+      case 3:
+        return 'text-xl';
+      case 4: 
+        return 'text-lg';
+      case 5:
+        return 'text-md';
+      default:
+        return 'text-lg lg:text-xl';
+    }
+  };
+
   return (
     <Card
       className={`w-full 'h-screen' bg-white border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700`}
@@ -55,10 +73,10 @@ const CameraCard: React.FC<CameraCardProps> = ({ camera, onSelect }) => {
         alt="Camera Snapshot"
         onLoad={() => setLoading(false)} 
       />
-      {!loading && ( 
-        <div className={`p-2 opacity-100`}>
+      {!loading && (
+        <div className={`p-2 opacity-100 ${calculateTextSize()}`}>
           <a href="#">
-            <h5 className="mb-2 text-xl lg:text-2xl font-bold tracking-tight text-gray-900 dark:text-white">{cameraName()}</h5>
+            <h5 className="mb-2 font-bold tracking-tight text-gray-900 dark:text-white">{cameraName()}</h5>
           </a>
         </div>
       )}

--- a/src/components/cameras/CameraCard.tsx
+++ b/src/components/cameras/CameraCard.tsx
@@ -60,7 +60,7 @@ const CameraCard: React.FC<CameraCardProps> = ({ camera, onSelect, columns }) =>
       onClick={handleSelect}
     >
       {loading && ( 
-        <div role="status" className="relative w-full h-full aspect-[1/1]">
+        <div role="status" className="relative w-full h-full aspect-[20/17]">
           <div className="absolute inset-0 flex items-center justify-center">
             <Spinner size="xl" />
           </div>

--- a/src/components/cameras/CameraCard.tsx
+++ b/src/components/cameras/CameraCard.tsx
@@ -8,7 +8,7 @@ interface CameraCardProps {
 }
 
 const CameraCard: React.FC<CameraCardProps> = ({ camera, onSelect }) => {
-  const [loading, setLoading] = useState(true); // Combine both loading states into one
+  const [loading, setLoading] = useState(true); 
 
   useEffect(() => {
     setLoading(true);
@@ -41,7 +41,7 @@ const CameraCard: React.FC<CameraCardProps> = ({ camera, onSelect }) => {
       className={`w-full 'h-screen' bg-white border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700`}
       onClick={handleSelect}
     >
-      {loading && ( // Use the combined loading state here
+      {loading && ( 
         <div role="status" className="relative w-full h-full aspect-[1/1]">
           <div className="absolute inset-0 flex items-center justify-center">
             <Spinner size="xl" />
@@ -49,13 +49,13 @@ const CameraCard: React.FC<CameraCardProps> = ({ camera, onSelect }) => {
         </div>
       )}
       <img
-        style={{ display: loading ? 'none' : 'block' }} // Use the combined loading state here
+        style={{ display: loading ? 'none' : 'block' }} 
         className={`rounded-t-lg w-full h-full transition-opacity duration-300 ${loading ? 'opacity-0' : 'opacity-100'}`} // Inverted opacity values
         src={camera.Url}
         alt="Camera Snapshot"
-        onLoad={() => setLoading(false)} // Set loading to false on image load
+        onLoad={() => setLoading(false)} 
       />
-      {!loading && ( // Use the combined loading state here
+      {!loading && ( 
         <div className={`p-2 opacity-100`}>
           <a href="#">
             <h5 className="mb-2 text-xl lg:text-2xl font-bold tracking-tight text-gray-900 dark:text-white">{cameraName()}</h5>

--- a/src/components/cameras/CameraCard.tsx
+++ b/src/components/cameras/CameraCard.tsx
@@ -5,27 +5,22 @@ import { CameraData } from '@/app/map/defs';
 interface CameraCardProps {
   camera: CameraData;
   onSelect: (camera: CameraData) => void;
-  totalColumns: () => number; // Add the totalColumns prop
 }
 
-const CameraCard: React.FC<CameraCardProps> = ({ camera, onSelect, totalColumns }) => {
-  const [loadedImage, setLoadedImage] = useState(false);
-  const [loadingImage, setLoadingImage] = useState(true);
-  const [cardHeight, setCardHeight] = useState<number | undefined>(undefined);
+const CameraCard: React.FC<CameraCardProps> = ({ camera, onSelect }) => {
+  const [loading, setLoading] = useState(true); // Combine both loading states into one
 
   useEffect(() => {
-    setLoadedImage(false);
-    setLoadingImage(true);
-    calculateCardHeight();
+    setLoading(true);
+
+    // timeout to stop infinite spinners
+    const timer = setTimeout(() => {
+      setLoading(false); 
+    }, 3000); 
+    
+    return () => clearTimeout(timer); 
   }, [camera.Url]);
 
-  const calculateCardHeight = () => {
-    if (typeof window !== 'undefined') {
-      const viewportHeight = window.innerHeight;
-      const cardHeight = viewportHeight / totalColumns(); // Adjust as needed
-      setCardHeight(cardHeight);
-    }
-  };
 
   const handleSelect = () => {
     onSelect(camera);
@@ -43,10 +38,10 @@ const CameraCard: React.FC<CameraCardProps> = ({ camera, onSelect, totalColumns 
 
   return (
     <Card
-      className={`w-full ${cardHeight ? `h-${cardHeight}` : 'h-full'} bg-white border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700`}
+      className={`w-full 'h-screen' bg-white border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700`}
       onClick={handleSelect}
     >
-      {loadingImage && (
+      {loading && ( // Use the combined loading state here
         <div role="status" className="relative w-full h-full aspect-[1/1]">
           <div className="absolute inset-0 flex items-center justify-center">
             <Spinner size="xl" />
@@ -54,17 +49,14 @@ const CameraCard: React.FC<CameraCardProps> = ({ camera, onSelect, totalColumns 
         </div>
       )}
       <img
-        style={{ display: loadedImage ? 'block' : 'none' }}
-        className={`rounded-t-lg w-full h-full transition-opacity duration-300 ${loadedImage ? 'opacity-100' : 'opacity-0'}`}
+        style={{ display: loading ? 'none' : 'block' }} // Use the combined loading state here
+        className={`rounded-t-lg w-full h-full transition-opacity duration-300 ${loading ? 'opacity-0' : 'opacity-100'}`} // Inverted opacity values
         src={camera.Url}
         alt="Camera Snapshot"
-        onLoad={() => {
-          setLoadedImage(true);
-          setLoadingImage(false);
-        }}
+        onLoad={() => setLoading(false)} // Set loading to false on image load
       />
-      {loadedImage && (
-        <div className={`p-2 ${loadedImage ? 'opacity-100' : 'opacity-0'}`}>
+      {!loading && ( // Use the combined loading state here
+        <div className={`p-2 opacity-100`}>
           <a href="#">
             <h5 className="mb-2 text-xl lg:text-2xl font-bold tracking-tight text-gray-900 dark:text-white">{cameraName()}</h5>
           </a>

--- a/src/components/cameras/CameraGrid.tsx
+++ b/src/components/cameras/CameraGrid.tsx
@@ -18,7 +18,7 @@ const CameraGrid: React.FC<CameraGridProps> = ({ cameras, section, gridSize, set
   const [selectedCamera, setSelectedCamera] = useState<CameraData | null>(null);
   const [loadedImages, setLoadedImages] = useState<Record<string, boolean>>({});
   const [currentPage, setCurrentPage] = useState(1);
-  const itemsPerPage = 12;
+  const itemsPerPage = 6;
 
   const gridRef = useRef<HTMLDivElement | null>(null);
 
@@ -86,28 +86,12 @@ const CameraGrid: React.FC<CameraGridProps> = ({ cameras, section, gridSize, set
     };
   }, [selectedCamera, cameras, section]);
 
-  const getTotalColumns = (): number => {
-  
-    const columns = parseInt(gridSize.replace("grid-cols-", ""), 10);
-  
-    if (!isNaN(columns)) {
-      return columns;
-    } else {
-      return 1; // Defaulting to 3 columns if parsing fails
-    }
-  };
-  
+
 
   return (
-    <div className='flex flex-col'>
-      <div ref={gridRef} className={`grid ${gridSize} gap-4 pl-10 text-black overflow-auto flex-grow`}>
-        {getCurrentPageCameras().map((camera, index) => (
-          <CameraCard key={index} camera={camera} onSelect={handleCardSelect} totalColumns={getTotalColumns} />
-        ))}
-        {selectedCamera && <CameraModal open={!!selectedCamera} onClose={() => setSelectedCamera(null)} selectedCamera={selectedCamera} />}
-      </div>
-      {Math.ceil(cameras[section].length) !== 0 && (
-        <div className="sticky bottom-0 z-5">
+    <div className='flex flex-col items-center'>
+      {Math.ceil(cameras[section].length / itemsPerPage) >= 1 && (
+        <div className="ml-10 md:ml-0 mb-4">
           <Pagination
             currentPage={currentPage}
             totalPages={Math.ceil(cameras[section].length / itemsPerPage)}
@@ -117,6 +101,12 @@ const CameraGrid: React.FC<CameraGridProps> = ({ cameras, section, gridSize, set
             onGoToLast={handleGoToLast} />
         </div>
       )}
+      <div ref={gridRef} className={`grid ${gridSize} gap-4 pl-10 text-black flex-grow w-full max-w-screen-lg`}>
+        {getCurrentPageCameras().map((camera, index) => (
+          <CameraCard key={index} camera={camera} onSelect={handleCardSelect} />
+        ))}
+        {selectedCamera && <CameraModal open={!!selectedCamera} onClose={() => setSelectedCamera(null)} selectedCamera={selectedCamera} />}
+      </div>
     </div>
   );
 };

--- a/src/components/cameras/CameraGrid.tsx
+++ b/src/components/cameras/CameraGrid.tsx
@@ -1,11 +1,9 @@
 import React, { useState, useEffect, useRef } from 'react';
-import Pagination from '../Pagination'; // Adjust the import path based on your actual file structure
+import Pagination from '../Pagination'; 
 import { CameraData } from '@/app/map/defs';
-import { sortCameras } from '@/app/cameras/sort';
 import { Section } from '@/app/cameras/defs';
 import CameraModal from '@/components/cameras/CameraModal';
-import { Spinner } from 'flowbite-react';
-import CameraCard from './CameraCard'; // Adjust the import path based on your actual file structure
+import CameraCard from './CameraCard'; 
 
 interface CameraGridProps {
   cameras: Record<Section, CameraData[]>;

--- a/src/components/cameras/CameraGrid.tsx
+++ b/src/components/cameras/CameraGrid.tsx
@@ -27,8 +27,9 @@ const CameraGrid: React.FC<CameraGridProps> = ({ cameras, section, gridSize, set
     if (gridRef.current) {
       gridRef.current.scrollTo(0, 0);
     }
-    setCurrentPage(1);
-  }, [section]);
+    const totalPages = Math.ceil(cameras[section].length / itemsPerPage);
+    setCurrentPage(prevPage => (prevPage <= totalPages ? prevPage : 1));
+  }, [section, cameras]);
 
   // Function to get the cameras for the current page
   const getCurrentPageCameras = (): CameraData[] => {
@@ -85,8 +86,6 @@ const CameraGrid: React.FC<CameraGridProps> = ({ cameras, section, gridSize, set
       document.removeEventListener('keydown', handleKeyDown);
     };
   }, [selectedCamera, cameras, section]);
-
-
 
   return (
     <div className='flex flex-col items-center'>

--- a/src/components/cameras/CameraGrid.tsx
+++ b/src/components/cameras/CameraGrid.tsx
@@ -89,25 +89,32 @@ const CameraGrid: React.FC<CameraGridProps> = ({ cameras, section, gridSize, set
 
   return (
     <div className='flex flex-col items-center'>
-      {Math.ceil(cameras[section].length / itemsPerPage) >= 1 && (
-        <div className="ml-10 md:ml-0 mb-4">
-          <Pagination
-            currentPage={currentPage}
-            totalPages={Math.ceil(cameras[section].length / itemsPerPage)}
-            onPrevPage={handlePrevPage}
-            onNextPage={handleNextPage}
-            onGoToBeginning={handleGoToBeginning}
-            onGoToLast={handleGoToLast} />
+      <div className='bg-white dark:bg-gray-800 w-full sticky top-60 md:top-32 z-10'>
+        {Math.ceil(cameras[section].length / itemsPerPage) >= 1 && (
+          <div className="my-2 ">
+            <Pagination
+              currentPage={currentPage}
+              totalPages={Math.ceil(cameras[section].length / itemsPerPage)}
+              onPrevPage={handlePrevPage}
+              onNextPage={handleNextPage}
+              onGoToBeginning={handleGoToBeginning}
+              onGoToLast={handleGoToLast}
+            />
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center justify-center overflow-y-auto flex-grow w-full">
+        <div ref={gridRef} className={`grid ${gridSize} gap-4 w-full max-w-screen-lg mt-2`}>
+          {getCurrentPageCameras().map((camera, index) => (
+            <CameraCard key={index} camera={camera} onSelect={handleCardSelect} />
+          ))}
+          {selectedCamera && <CameraModal open={!!selectedCamera} onClose={() => setSelectedCamera(null)} selectedCamera={selectedCamera} />}
         </div>
-      )}
-      <div ref={gridRef} className={`grid ${gridSize} gap-4 pl-10 text-black flex-grow w-full max-w-screen-lg`}>
-        {getCurrentPageCameras().map((camera, index) => (
-          <CameraCard key={index} camera={camera} onSelect={handleCardSelect} />
-        ))}
-        {selectedCamera && <CameraModal open={!!selectedCamera} onClose={() => setSelectedCamera(null)} selectedCamera={selectedCamera} />}
       </div>
     </div>
   );
+
 };
 
 export default CameraGrid;

--- a/src/components/cameras/CameraGrid.tsx
+++ b/src/components/cameras/CameraGrid.tsx
@@ -16,7 +16,8 @@ const CameraGrid: React.FC<CameraGridProps> = ({ cameras, section, gridSize, set
   const [selectedCamera, setSelectedCamera] = useState<CameraData | null>(null);
   const [loadedImages, setLoadedImages] = useState<Record<string, boolean>>({});
   const [currentPage, setCurrentPage] = useState(1);
-  const itemsPerPage = 6;
+  const columns = gridSize.includes('grid-cols-') ? parseInt(gridSize.split('-')[2]) : 3;
+  const itemsPerPage = columns === 1 ? 6 : columns * 2;
 
   const gridRef = useRef<HTMLDivElement | null>(null);
 
@@ -105,7 +106,7 @@ const CameraGrid: React.FC<CameraGridProps> = ({ cameras, section, gridSize, set
       <div className="flex items-center justify-center overflow-y-auto flex-grow w-full">
         <div ref={gridRef} className={`grid ${gridSize} gap-4 w-full max-w-screen-lg mt-2`}>
           {getCurrentPageCameras().map((camera, index) => (
-            <CameraCard key={index} camera={camera} onSelect={handleCardSelect} />
+            <CameraCard key={index} camera={camera} onSelect={handleCardSelect} columns={columns} />
           ))}
           {selectedCamera && <CameraModal open={!!selectedCamera} onClose={() => setSelectedCamera(null)} selectedCamera={selectedCamera} />}
         </div>

--- a/src/components/cameras/CameraGridSize.tsx
+++ b/src/components/cameras/CameraGridSize.tsx
@@ -30,7 +30,7 @@ const CameraGridSize = ({ onAddColumns, onReduceColumns, gridSize }: CameraGridS
   }
 
   return (
-    <div className="p-4 fixed hidden sm:block bottom-5 right-0 z-index-1001">
+    <div className="p-4 fixed hidden sm:block bottom-5 right-0 z-100">
       <div className='flex gap-2'>
         <Button
           onClick={handleAdd}

--- a/src/components/cameras/CameraSearch.tsx
+++ b/src/components/cameras/CameraSearch.tsx
@@ -35,7 +35,7 @@ const CameraSearch: React.FC<CameraSearchProps> = ({ currentCameras, onSearchRes
   };
 
   return (
-    <div className="mb-4 flex flex-col sm:flex-row gap-4 mt-2">
+    <div className="mb-4 flex flex-col sm:flex-row gap-4 pt-2">
       <input
         type="text"
         placeholder="Search cameras..."

--- a/src/components/cameras/CameraSearch.tsx
+++ b/src/components/cameras/CameraSearch.tsx
@@ -35,7 +35,7 @@ const CameraSearch: React.FC<CameraSearchProps> = ({ currentCameras, onSearchRes
   };
 
   return (
-    <div className="mb-4 flex flex-col sm:flex-row gap-4">
+    <div className="mb-4 flex flex-col sm:flex-row gap-4 mt-2">
       <input
         type="text"
         placeholder="Search cameras..."
@@ -44,12 +44,14 @@ const CameraSearch: React.FC<CameraSearchProps> = ({ currentCameras, onSearchRes
         onKeyDown={handleKeyDown}
         className="p-2 border border-gray-300 rounded-md dark:bg-gray-800 dark:border-gray-700 dark:text-white dark:placeholder:text-gray-400"
       />
-      <Button onClick={handleSearch} className='bg-black enabled:hover:bg-gray-600 dark:bg-white dark:enabled:hover:bg-gray-600 dark:enabled:hover:text-white dark:text-black'>
-        Search
-      </Button>
-      <Button onClick={resetSearch} className='bg-black enabled:hover:bg-gray-600 dark:bg-white dark:enabled:hover:bg-gray-600 dark:enabled:hover:text-white dark:text-black'>
-        Reset
-      </Button>
+      <div className='flex gap-4'>
+        <Button onClick={handleSearch} className='w-1/2 bg-black enabled:hover:bg-gray-600 dark:bg-white dark:enabled:hover:bg-gray-600 dark:enabled:hover:text-white dark:text-black'>
+          Search
+        </Button>
+        <Button onClick={resetSearch} className='w-1/2 bg-black enabled:hover:bg-gray-600 dark:bg-white dark:enabled:hover:bg-gray-600 dark:enabled:hover:text-white dark:text-black'>
+          Reset
+        </Button>
+      </div>
     </div>
   );
 };

--- a/src/components/cameras/CameraSidebar.tsx
+++ b/src/components/cameras/CameraSidebar.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useImperativeHandle, useState } from 'react';
-import { ListGroup, Sidebar } from 'flowbite-react';
+import { Sidebar } from 'flowbite-react';
 import { TbLetterC, TbLetterA, TbLetterE, TbLetterB } from 'react-icons/tb';
 import { Section } from '@/app/cameras/defs'
 import { SideBar } from '@/components/SideBar';

--- a/src/components/cameras/CameraSidebar.tsx
+++ b/src/components/cameras/CameraSidebar.tsx
@@ -12,7 +12,7 @@ interface CameraSidebarProps {
 
 const CameraSidebar = forwardRef(({ onSectionSelect, showSideBar, setShowSideBar }: CameraSidebarProps, ref) => {
   const sections: Section[] = ['alberta-highways', 'calgary-cameras', 'edmonton-cameras', 'banff-cameras'];
-  const icons: any[] = [TbLetterA, TbLetterC, TbLetterE, TbLetterB  ];
+  const icons: any[] = [TbLetterA, TbLetterC, TbLetterE, TbLetterB];
   const [isOpen, setIsOpen] = useState(false);
   const [activeSectionIndex, setActiveSectionIndex] = useState(0);
 
@@ -31,24 +31,27 @@ const CameraSidebar = forwardRef(({ onSectionSelect, showSideBar, setShowSideBar
   }));
 
   return (
-    <SideBar handleToggleSidebar={handleToggleSidebar} isOpen={showSideBar && isOpen} pt={0}>
-      <Sidebar className="w-full">
-        <Sidebar.Items>
-          <Sidebar.ItemGroup>
-            {sections.map((section, index) => (
-              <Sidebar.Item
-                key={section}
-                onClick={() => handleSelect(index)}
-                active={index === activeSectionIndex}
-                icon={icons[index]}
-              >
-                {section.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')}
-              </Sidebar.Item>
-            ))}
-          </Sidebar.ItemGroup>
-        </Sidebar.Items>
-      </Sidebar>
-    </SideBar>
+    <div>
+      <SideBar handleToggleSidebar={handleToggleSidebar} isOpen={showSideBar && isOpen} pt={0}>
+        <Sidebar className="w-full">
+          <Sidebar.Items>
+            <Sidebar.ItemGroup>
+              {sections.map((section, index) => (
+                <Sidebar.Item
+                  key={section}
+                  onClick={() => handleSelect(index)}
+                  active={index === activeSectionIndex}
+                  icon={icons[index]}
+                >
+                  {section.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')}
+                </Sidebar.Item>
+              ))}
+            </Sidebar.ItemGroup>
+          </Sidebar.Items>
+        </Sidebar>
+      </SideBar>
+    </div>
+
   );
 });
 

--- a/src/components/cameras/Cameras.tsx
+++ b/src/components/cameras/Cameras.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, FC, useRef, useEffect } from 'react';
+import React, { useState, useCallback, useRef, useEffect } from 'react';
 import CameraSidebar from '@/components/cameras/CameraSidebar';
 import CameraGrid from '@/components/cameras/CameraGrid';
 import CameraGridSize from '@/components/cameras/CameraGridSize';

--- a/src/components/cameras/Cameras.tsx
+++ b/src/components/cameras/Cameras.tsx
@@ -91,13 +91,13 @@ const Cameras: React.FC<CamerasProps> = ({ }) => {
   };
 
   return (
-    <div className="flex min-h-screen bg-white dark:bg-gray-800">
+    <div className="flex bg-white dark:bg-gray-800">
       <div className="flex">
         <CameraSidebar ref={sidebarRef} onSectionSelect={setSelectedSection} showSideBar={showSidebar} setShowSideBar={setShowSidebar} />
       </div>
-      <div className="flex-1 overflow-auto min-h-screen p-1" onClick={() => setShowSidebar(false)}>
+      <div className="flex-1 p-1" onClick={() => setShowSidebar(false)}>
         <div className='ml-10 flex flex-col sm:flex-row justify-between gap-4'>
-          <h1 className='text-lg dark:text-white'>
+          <h1 className='text-lg dark:text-white mt-2'>
             Viewing {formatSectionName(selectedSection)}
           </h1>
           <CameraSearch

--- a/src/components/cameras/Cameras.tsx
+++ b/src/components/cameras/Cameras.tsx
@@ -91,13 +91,13 @@ const Cameras: React.FC<CamerasProps> = ({ }) => {
   };
 
   return (
-    <div className="flex bg-white dark:bg-gray-800">
-      <div className="flex">
-        <CameraSidebar ref={sidebarRef} onSectionSelect={setSelectedSection} showSideBar={showSidebar} setShowSideBar={setShowSidebar} />
-      </div>
-      <div className="flex-1 p-1" onClick={() => setShowSidebar(false)}>
-        <div className='ml-10 flex flex-col sm:flex-row justify-between gap-4'>
-          <h1 className='text-lg dark:text-white mt-2'>
+    <div className="flex flex-col bg-white dark:bg-gray-800">
+      <div className="flex flex-col sticky w-full top-16 bg-white dark:bg-gray-800 z-20">
+        <div className="flex z-50">
+          <CameraSidebar ref={sidebarRef} onSectionSelect={setSelectedSection} showSideBar={showSidebar} setShowSideBar={setShowSidebar} />
+        </div>
+        <div className='flex flex-col sm:flex-row justify-between gap-4 px-2'>
+          <h1 className='ml-10 text-lg dark:text-white mt-2'>
             Viewing {formatSectionName(selectedSection)}
           </h1>
           <CameraSearch
@@ -105,7 +105,11 @@ const Cameras: React.FC<CamerasProps> = ({ }) => {
             onSearchResult={(filteredCameras) => setFilteredCameras({ ...cameras, [selectedSection]: filteredCameras })}
           />
         </div>
-        {loading ? (
+        
+      </div>
+      
+      <div>
+      {loading ? (
           <div className='flex items-center justify-center h-screen'>
             <Spinner size="xl" />
           </div>
@@ -116,7 +120,6 @@ const Cameras: React.FC<CamerasProps> = ({ }) => {
             gridSize={gridSize}
             setCameras={setCameras}
           />
-
         )}
       </div>
       <CameraGridSize onReduceColumns={reduceColumns} onAddColumns={addColumns} gridSize={gridSize} />


### PR DESCRIPTION
Don't merge until we figure out where this transparent bar b/w the navbar and the section right below.
the navbar shadow isn't the problem because you can see the cameras when scrolling on mobile or with 1 column (and I tried to see if removing it fixed it) 
My best guess is some margin or padding somewhere that I can't find

Changes:
- Changes in Navbar.tsx were to get rid of a space stopping the dark mode change 
- [ ] check this if I need to remove any changes in the above file for this branch
- Search, pagination, and navbar sticky on cameras page
- Pagination shows X/Y instead of Page X of Y for mobile
- removed the double loading states for the card and added a timeout to prevent infinite spinners (3 seconds currently will likely lower)
- search will no longer leave you on a page that doesn't have cameras (reset still leaves you on your current page)
- removed useless gridsize function
- pagination above the grid
- [ ] check this if you want the pagination underneath the search on the right instead of center
- text size changes with grid size
- always two full rows of cameras in the grid unless the grid size is 1 then show 6 items so mobile has something to scroll
- fixed spinner ratio

